### PR TITLE
Fix the size of statement parameters

### DIFF
--- a/Database/HDBC/ODBC/Statement.hsc
+++ b/Database/HDBC/ODBC/Statement.hsc
@@ -275,8 +275,8 @@ bindParam sthptr arg icol =  alloca $ \pdtype ->
                      rc2 <- sqlBindParameter sthptr (fromIntegral icol)
                        #{const SQL_PARAM_INPUT}
                        #{const SQL_C_CHAR} coltype 
-                       (if isOK rc1 then colsize else fromIntegral cslen + 1) decdigits
-                       csptr (fromIntegral cslen + 1) pcslen
+                       (if isOK rc1 then colsize else fromIntegral cslen) decdigits
+                       csptr (fromIntegral cslen) pcslen
                      if isOK rc2
                         then do -- We bound it.  Make foreignPtrs and return.
                                 return $ Just (pcslen, csptr)


### PR DESCRIPTION
hdbc-odbc adds a space to data submitted via parameters.
I reported the bug on haskell-cafe quite some time ago:
https://groups.google.com/forum/?hl=en&fromgroups=#!topic/haskell-cafe/PLFvoo5bYug
