### PR TITLE
Attempt to fetch errors from compound statements

### DIFF
--- a/Database/HDBC/ODBC/ConnectionImpl.hs
+++ b/Database/HDBC/ODBC/ConnectionImpl.hs
@@ -3,6 +3,7 @@ module Database.HDBC.ODBC.ConnectionImpl where
 import qualified Database.HDBC.Statement as Types
 import qualified Database.HDBC.Types as Types
 import Database.HDBC.ColTypes as ColTypes
+import Control.Exception (finally)
 
 data Connection =
     Connection {
@@ -30,6 +31,9 @@ instance Types.IConnection Connection where
   commit = commit
   rollback = rollback
   run = run
+  runRaw conn sql = do
+    sth <- prepare conn sql
+    Types.executeRaw sth `finally` Types.finish sth
   prepare = prepare
   clone = clone
   hdbcDriverName = hdbcDriverName


### PR DESCRIPTION
When statements like "success; fail" are executed, HDBC-odbc doesn't throw
an exception for the failing second statement.  To fix this case, we've
implemented executeRaw and called it from class method runRaw.

This has been tested on Linux with Microsoft's ODBC driver only so far.

This also happens to fix issue #16 
