### PR TITLE
Bind SqlUTCTime and SqlLocalTime to SQL_TIMESTAMP in query arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist*
+.stack-work

--- a/HDBC-odbc.cabal
+++ b/HDBC-odbc.cabal
@@ -1,5 +1,5 @@
 name:          HDBC-odbc
-version:       2.5.0.1
+version:       2.5.1
 cabal-version: >=1.8
 build-type:    Simple
 license:       BSD3


### PR DESCRIPTION
This fixes using `SqlUTCTime`/`SqlLocalTime` which would otherwise be bound as `SQL_VARCHAR` that would fail with the backend.

In my case in particular this allowed to use `UTCTime` arguments in Persistent queries with Oracle 12C.