### PR TITLE
Do not use unicode API on non-windows

### DIFF
--- a/Database/HDBC/ODBC/Api/Errors.hs
+++ b/Database/HDBC/ODBC/Api/Errors.hs
@@ -38,20 +38,44 @@ foreign import ccall safe "sqlSucceeded"
 sqlSucceeded :: SQLRETURN -> Bool
 sqlSucceeded x = c_sqlSucceeded x /= 0
 
+-- ODBC uses Windows unicode convention (i.e. UCS-2 encoding and
+-- 2-byte wchar_t), and is incompatible with Unix wchar_t.  See
+-- https://www.easysoft.com/developer/interfaces/odbc/linux.html#unicode_unixodbc
+-- for more information.
+#ifdef mingw32_HOST_OS
 getDiag :: SQLSMALLINT -> SQLHANDLE -> SQLSMALLINT -> IO [(String, String)]
 getDiag ht hp irow =
-  allocaBytes 6 $ \csstate ->
+  allocaBytes (6 * sizeOf (undefined :: CWchar)) $ \csstate ->
   alloca $ \pnaterr ->
-  allocaBytes 1025 $ \csmsg ->
+  allocaBytes (1024 * sizeOf (undefined :: CWchar)) $ \csmsg ->
   alloca $ \pmsglen -> do
     ret <- c_sqlGetDiagRecW ht hp irow csstate pnaterr csmsg 1024 pmsglen
     if sqlSucceeded ret
      then do
-      state <- peekCWStringLen (csstate, 5)
+      state <- peekCWString csstate
       nat <- peek pnaterr
       msglen <- peek pmsglen
-      msgstr <- peekCWStringLen (csmsg, fromIntegral msglen)
+      msgstr <- peekCWString csmsg
       next <- getDiag ht hp (irow + 1)
       return $ (state, show nat ++ ": " ++ msgstr) : next
     else
       return []
+#else
+getDiag :: SQLSMALLINT -> SQLHANDLE -> SQLSMALLINT -> IO [(String, String)]
+getDiag ht hp irow =
+  allocaBytes 6 $ \csstate ->
+  alloca $ \pnaterr ->
+  allocaBytes 1024 $ \csmsg ->
+  alloca $ \pmsglen -> do
+    ret <- c_sqlGetDiagRec ht hp irow csstate pnaterr csmsg 1024 pmsglen
+    if sqlSucceeded ret
+     then do
+      state <- peekCString csstate
+      nat <- peek pnaterr
+      msglen <- peek pmsglen
+      msgstr <- peekCString csmsg
+      next <- getDiag ht hp (irow + 1)
+      return $ (state, show nat ++ ": " ++ msgstr) : next
+    else
+      return []
+#endif


### PR DESCRIPTION
This pull request changes the diagnostics code to not use the UNICODE API on Unix, as the conventions used in ODBC are based in Windows and are incompatible with UNIX systems.

The code is based on https://github.com/abbradar/hdbc-odbc/commit/79ffd1f5060d2c8b5cbdfd4eba8ae6414372d6b7, but will still use the UNICODE API on Windows.