### PR TITLE
Fix #14

### DIFF
--- a/Database/HDBC/ODBC/Connection.hsc
+++ b/Database/HDBC/ODBC/Connection.hsc
@@ -117,7 +117,7 @@ mkConn args iconn = withDbcOrDie iconn $ \cconn ->
        clientname <- peekCStringLen (pbuf, fromIntegral len)
 
        sqlGetInfo cconn #{const SQL_TXN_CAPABLE} (castPtr psqlusmallint)
-                      0 nullPtr
+                      #{size SQLUSMALLINT} nullPtr
          >>= checkError "sqlGetInfo SQL_TXN_CAPABLE" (DbcHandle cconn)
        txninfo <- ((peek psqlusmallint)::IO (#{type SQLUSMALLINT}))
        let txnsupport = txninfo /= #{const SQL_TC_NONE}


### PR DESCRIPTION
@derrickturk has identified (https://github.com/derrickturk/hdbc-odbc/commit/99cbefb16defc9ce6de77c1434207a78b5c3c365) that, in the case of the MS Access ODBC driver, the `BufferLength` argument of ODBC API function `SQLGetInfo` cannot be ignored (that is, set to 0), despite what is implied by the Microsoft API documentation (https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetinfo-function?view=sql-server-2017).

`InfoType` `SQL_TXN_CAPABLE` returns a `SQLUSMALLINT` value and the `BufferLength` must be set accordingly.