### PR TITLE
Fix segfault for ghc 9.2

### DIFF
--- a/Database/HDBC/ODBC/Connection.hsc
+++ b/Database/HDBC/ODBC/Connection.hsc
@@ -168,6 +168,7 @@ fdisconnect :: DbcWrapper -> ChildList -> IO ()
 fdisconnect iconn mchildren  = do
   closeAllChildren mchildren
   freeDbcIfNotAlready True iconn
+{-# NOINLINE fdisconnect #-}
 
 fGetAutoCommit :: SQLHDBC -> IO Bool
 fGetAutoCommit hdbc = do


### PR DESCRIPTION
I tried to upgrade my compiler to ghc 9.2.5 and the who thing just stopped working. Ultimately, I found that the `freeDbcIfNotAlready` is being started practically at the first GC cycle. It seems the compiler was able to optimize the structure out by inlining the functions so that in the end there was nothing pointing to the `DbcWrapper`.

Marking one of the function that use the wrapper`NOINLINE` seems to help; though, it seems to me some other solution might be well preferable (in the end, using some kind of `with` function usually works better).