### PR TITLE
Fix crashes on newer GHC (9.0+)

### DIFF
--- a/Database/HDBC/ODBC/Wrappers.hs
+++ b/Database/HDBC/ODBC/Wrappers.hs
@@ -55,7 +55,7 @@ sqlAllocEnv = do
     handleVar <- newMVar (Just hEnv)
     let wrapper = EnvWrapper handleVar
 
-    _ <- mkWeakMVar handleVar $ freeEnvIfNotAlready wrapper
+    mkWeakMVar handleVar $ freeEnvIfNotAlready wrapper
     return wrapper
 
 freeEnvIfNotAlready :: EnvWrapper -> IO ()
@@ -98,7 +98,7 @@ sqlAllocDbc env = do
   oldStmtsVar <- newMVar []
   let wrapper = DbcWrapper handleVar env oldStmtsVar
 
-  _ <- mkWeakMVar oldStmtsVar (freeDbcIfNotAlready False wrapper)
+  mkWeakMVar oldStmtsVar $ freeDbcIfNotAlready False wrapper
   return wrapper
 
 freeOldStmts :: DbcWrapper -> IO ()

--- a/Database/HDBC/ODBC/Wrappers.hs
+++ b/Database/HDBC/ODBC/Wrappers.hs
@@ -55,7 +55,7 @@ sqlAllocEnv = do
     handleVar <- newMVar (Just hEnv)
     let wrapper = EnvWrapper handleVar
 
-    addFinalizer wrapper $ freeEnvIfNotAlready wrapper
+    _ <- mkWeakMVar handleVar $ freeEnvIfNotAlready wrapper
     return wrapper
 
 freeEnvIfNotAlready :: EnvWrapper -> IO ()
@@ -98,7 +98,7 @@ sqlAllocDbc env = do
   oldStmtsVar <- newMVar []
   let wrapper = DbcWrapper handleVar env oldStmtsVar
 
-  addFinalizer wrapper $ freeDbcIfNotAlready False wrapper
+  _ <- mkWeakMVar oldStmtsVar (freeDbcIfNotAlready False wrapper)
   return wrapper
 
 freeOldStmts :: DbcWrapper -> IO ()
@@ -163,7 +163,7 @@ sqlAllocStmt dbc = do
   handleVar <- newMVar $ Just hStmt
   let wrapper = StmtWrapper handleVar dbc
 
-  addFinalizer wrapper $ freeStmtIfNotAlready wrapper
+  mkWeakMVar handleVar $ freeStmtIfNotAlready wrapper
   return wrapper
 
 freeStmtIfNotAlready :: StmtWrapper -> IO ()


### PR DESCRIPTION
Osiginal code breaks if compiled with GHC 9.0+ -- seems like connection handler is finalized too early. Binaries compiled with previous GHC <8 are fine.
Examples and more info can be found in [my fork](https://github.com/supersonic-copycat/hdbc-odbc/).

Solution is taken from [discussion of this pull request](https://github.com/hdbc/hdbc-odbc/pull/48).
That should fix #49 